### PR TITLE
Fix Prisma output path and stabilize game state handling

### DIFF
--- a/app/components/game-control-panel.tsx
+++ b/app/components/game-control-panel.tsx
@@ -40,7 +40,7 @@ export function GameControlPanel({
   const [timeElapsed, setTimeElapsed] = React.useState(0);
 
   React.useEffect(() => {
-    let interval: NodeJS.Timeout;
+    let interval: ReturnType<typeof setInterval> | undefined;
     
     if (gameState.gameActive && gameState.startTime) {
       interval = setInterval(() => {

--- a/app/components/main-game.tsx
+++ b/app/components/main-game.tsx
@@ -31,7 +31,7 @@ export function MainGame() {
 
     const handleFeedback = (feedback: FeedbackMessage) => {
       setFeedbackMessages(prev => [...prev, feedback]);
-      
+
       // Auto-dismiss non-critical messages after 5 seconds
       if (feedback.type === 'info' || feedback.type === 'warning') {
         setTimeout(() => {
@@ -40,19 +40,23 @@ export function MainGame() {
       }
     };
 
-    gameEngine.onFeedback(handleFeedback);
-    
+    const unsubscribe = gameEngine.onFeedback(handleFeedback);
+
+    // Ensure the latest engine state is reflected immediately
+    updateState();
+
     // Set up polling for state updates
     const interval = setInterval(updateState, 100);
-    
+
     return () => {
       clearInterval(interval);
+      unsubscribe();
     };
   }, [gameEngine]);
 
   React.useEffect(() => {
-    let interval: NodeJS.Timeout;
-    
+    let interval: ReturnType<typeof setInterval> | undefined;
+
     if (gameState.gameActive && gameState.startTime) {
       interval = setInterval(() => {
         setTimeElapsed(Math.floor((Date.now() - gameState.startTime!.getTime()) / 1000));
@@ -63,6 +67,12 @@ export function MainGame() {
       if (interval) clearInterval(interval);
     };
   }, [gameState.gameActive, gameState.startTime]);
+
+  React.useEffect(() => {
+    if (!selectedScenario && availableScenarios.length > 0) {
+      setSelectedScenario(availableScenarios[0]);
+    }
+  }, [selectedScenario, availableScenarios]);
 
   React.useEffect(() => {
     if (gameState.gameCompleted) {

--- a/app/hooks/use-toast.ts
+++ b/app/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/app/lib/game-engine.ts
+++ b/app/lib/game-engine.ts
@@ -214,8 +214,12 @@ export class ConveyXGameEngine {
     this.feedbackCallbacks.forEach(callback => callback(feedback));
   }
 
-  public onFeedback(callback: (feedback: FeedbackMessage) => void): void {
+  public onFeedback(callback: (feedback: FeedbackMessage) => void): () => void {
     this.feedbackCallbacks.push(callback);
+
+    return () => {
+      this.feedbackCallbacks = this.feedbackCallbacks.filter(cb => cb !== callback);
+    };
   }
 
   public getGameState(): GameState {

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -5,7 +5,6 @@
 generator client {
     provider = "prisma-client-js"
     binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
-    output = "/home/ubuntu/conveyx_training_game/app/node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- remove the hard-coded Prisma client output path so the schema can generate on any machine
- add cleanup logic for the client-side game engine feedback listeners and select a default scenario automatically
- stabilize interval typings and the toast hook subscription to avoid leaks during client-side updates

## Testing
- not run (dependency installation requires network access)

------
https://chatgpt.com/codex/tasks/task_e_68da41d2642c8322a29056f87272d019