### PR TITLE
Add README with link to app entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# ConveyX Training Game
+
+This repository contains the ConveyX Training Game web application. It is built with Next.js and provides the main experience for practicing ConveyX workflows.
+
+## Viewing the App
+
+Once the development server is running, open the main page at [http://localhost:3000/](http://localhost:3000/). This serves the `HomePage` component located in `app/app/page.tsx`.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   cd app
+   yarn install
+   ```
+2. Run the development server:
+   ```bash
+   yarn dev
+   ```
+3. Visit the app in your browser using the link above.
+
+## Repository Structure
+
+- `app/` – Next.js application source, including pages, components, and configuration.
+- `prisma/` – Database schema and Prisma client setup.
+- `scripts/` – Utility scripts for development.
+
+Feel free to explore the codebase to understand how the training game is implemented.


### PR DESCRIPTION
## Summary
- add a repository README with an overview of the ConveyX Training Game
- document how to run the app locally and link to the main page at http://localhost:3000/

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68da4c3f524c8322a621ec89470cef14