### PR TITLE
Configure Next.js build for GitHub Pages deployment

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,9 +1,17 @@
 const path = require('path');
 
+const repositoryName = 'conveyx-training-game';
+const isGitHubPages = process.env.GITHUB_PAGES === 'true';
+const configuredBasePath = process.env.NEXT_PUBLIC_BASE_PATH || (isGitHubPages ? `/${repositoryName}` : '');
+const configuredAssetPrefix = process.env.NEXT_PUBLIC_ASSET_PREFIX || (configuredBasePath ? configuredBasePath : '');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   distDir: process.env.NEXT_DIST_DIR || '.next',
-  output: process.env.NEXT_OUTPUT_MODE,
+  output: process.env.NEXT_OUTPUT_MODE || 'export',
+  ...(configuredBasePath ? { basePath: configuredBasePath } : {}),
+  ...(configuredAssetPrefix ? { assetPrefix: configuredAssetPrefix } : {}),
+  trailingSlash: true,
   experimental: {
     outputFileTracingRoot: path.join(__dirname, '../'),
   },


### PR DESCRIPTION
## Summary
- default the Next.js build to static export mode and enable trailing slashes to support GitHub Pages
- automatically derive the correct base path and asset prefix for the conveyx-training-game repository when publishing to GitHub Pages

## Testing
- Attempted `yarn install --frozen-lockfile` *(fails: lockfile symlink in repo points to a missing path so Yarn refuses to proceed)*

------
https://chatgpt.com/codex/tasks/task_e_68da4faa3bd8832297d8909b672ec087