### PR TITLE
Add landing page linking to training simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the ConveyX Training Game web application. It is built 
 
 ## Viewing the App Locally
 
-Once the development server is running, open the main page at [http://localhost:3000/](http://localhost:3000/). This serves the `HomePage` component located in `app/app/page.tsx`.
+Once the development server is running, open the landing page at [http://localhost:3000/](http://localhost:3000/). From there you can launch the interactive training experience at [http://localhost:3000/training](http://localhost:3000/training), which renders the `MainGame` component.
 
 ## Getting Started
 

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,6 +1,30 @@
-
-import { MainGame } from '@/components/main-game';
+import Link from 'next/link';
+import { ArrowRight, Zap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 export default function HomePage() {
-  return <MainGame />;
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900">
+      <div className="max-w-5xl mx-auto px-6 py-24 flex flex-col items-center text-center gap-8">
+        <span className="inline-flex items-center gap-2 rounded-full bg-blue-100/80 dark:bg-blue-900/40 px-4 py-1 text-sm font-medium text-blue-700 dark:text-blue-200">
+          <Zap className="h-4 w-4" />
+          ConveyX Training Suite
+        </span>
+        <h1 className="text-4xl sm:text-6xl font-bold tracking-tight text-slate-900 dark:text-white">
+          Master Mod-LinX troubleshooting with our interactive simulator
+        </h1>
+        <p className="text-lg sm:text-xl text-slate-600 dark:text-slate-300 max-w-3xl">
+          Step into a realistic operations environment that helps technicians practice diagnosing faults
+          across ConveyX Mod-LinX conveyor systems. Launch the training app to explore live scenarios
+          and improve your response time.
+        </p>
+        <Button asChild size="lg" className="group">
+          <Link href="/training" className="flex items-center gap-2">
+            Launch Training App
+            <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+          </Link>
+        </Button>
+      </div>
+    </main>
+  );
 }

--- a/app/app/training/page.tsx
+++ b/app/app/training/page.tsx
@@ -1,0 +1,5 @@
+import { MainGame } from '@/components/main-game';
+
+export default function TrainingPage() {
+  return <MainGame />;
+}


### PR DESCRIPTION
## Summary
- replace the root index page with a marketing-style landing screen that links to the simulator
- move the training experience to a dedicated /training route that renders the existing MainGame component
- document the landing and training URLs in the README

## Testing
- yarn lint *(fails: requires dependencies that cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db21bd559483229bd7f4e7b3a73722