### PR TITLE
Add collapsible feedback sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,33 @@
       <button id="newScenarioButton" class="secondary">New Scenario</button>
     </div>
 
+    <!-- Floating feedback sidebar so hints are visible near the controls -->
+    <aside id="feedbackSidebar" class="feedback-sidebar" aria-live="polite">
+      <button
+        id="feedbackSidebarToggle"
+        class="feedback-sidebar-toggle"
+        type="button"
+        aria-controls="feedbackSidebarPanel"
+        aria-expanded="true"
+      >
+        Hide Feedback
+      </button>
+      <div id="feedbackSidebarPanel" class="feedback-sidebar-panel" role="complementary">
+        <div class="feedback-sidebar-header">
+          <h2>💡 Feedback Per Move</h2>
+          <button
+            id="feedbackSidebarClose"
+            class="feedback-sidebar-close"
+            type="button"
+            aria-label="Close feedback panel"
+          >
+            ×
+          </button>
+        </div>
+        <div id="feedbackSidebarContent" class="feedback-sidebar-content">No feedback yet.</div>
+      </div>
+    </aside>
+
     <!-- Container where the panels will be rendered -->
     <div id="panel-container" class="panel-container"></div>
     <!-- Feedback area for messages -->

--- a/script.js
+++ b/script.js
@@ -28,6 +28,45 @@ const panelContainer = document.getElementById('panel-container');
 const startButton = document.getElementById('startButton');
 const newScenarioButton = document.getElementById('newScenarioButton');
 const feedbackEl = document.getElementById('feedback');
+const feedbackSidebar = document.getElementById('feedbackSidebar');
+const feedbackSidebarContent = document.getElementById('feedbackSidebarContent');
+const feedbackSidebarToggle = document.getElementById('feedbackSidebarToggle');
+const feedbackSidebarClose = document.getElementById('feedbackSidebarClose');
+
+// Track whether the player intentionally collapsed the sidebar
+let sidebarManuallyCollapsed = false;
+
+/**
+ * Update the sidebar collapsed state and synchronise accessibility attributes.
+ */
+function setSidebarCollapsed(collapsed) {
+  if (!feedbackSidebar || !feedbackSidebarToggle) return;
+  feedbackSidebar.classList.toggle('collapsed', collapsed);
+  feedbackSidebarToggle.setAttribute('aria-expanded', String(!collapsed));
+  feedbackSidebarToggle.textContent = collapsed ? 'Show Feedback' : 'Hide Feedback';
+  if (collapsed) {
+    feedbackSidebar.setAttribute('aria-hidden', 'true');
+  } else {
+    feedbackSidebar.removeAttribute('aria-hidden');
+  }
+}
+
+if (feedbackSidebarToggle) {
+  feedbackSidebarToggle.addEventListener('click', () => {
+    if (!feedbackSidebar) return;
+    const collapsed = !feedbackSidebar.classList.contains('collapsed');
+    sidebarManuallyCollapsed = collapsed;
+    setSidebarCollapsed(collapsed);
+  });
+}
+
+if (feedbackSidebarClose) {
+  feedbackSidebarClose.addEventListener('click', () => {
+    if (!feedbackSidebar) return;
+    sidebarManuallyCollapsed = true;
+    setSidebarCollapsed(true);
+  });
+}
 
 /**
  * Initialize a new game scenario.
@@ -328,9 +367,23 @@ function updateFeedback(message) {
   if (!message) {
     feedbackEl.style.display = 'none';
     feedbackEl.textContent = '';
+    if (feedbackSidebarContent) {
+      feedbackSidebarContent.textContent = 'No feedback yet.';
+    }
+    sidebarManuallyCollapsed = false;
+    setSidebarCollapsed(true);
   } else {
     feedbackEl.style.display = 'block';
     feedbackEl.textContent = message;
+    if (feedbackSidebarContent) {
+      feedbackSidebarContent.textContent = message;
+    }
+    if (!sidebarManuallyCollapsed) {
+      setSidebarCollapsed(false);
+    } else if (feedbackSidebar) {
+      // Even if manually collapsed, update button text state
+      setSidebarCollapsed(feedbackSidebar.classList.contains('collapsed'));
+    }
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -186,6 +186,116 @@ button.secondary:hover {
   display: none; /* hidden until there is feedback */
 }
 
+/* Floating feedback sidebar */
+.feedback-sidebar {
+  position: fixed;
+  top: 6rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+  z-index: 1000;
+}
+
+.feedback-sidebar-toggle {
+  background-color: var(--accent);
+  color: #ffffff;
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.4rem 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  transition: background-color var(--transition-speed), box-shadow var(--transition-speed);
+}
+
+.feedback-sidebar-toggle:hover,
+.feedback-sidebar-toggle:focus {
+  background-color: var(--accent-light);
+  outline: none;
+}
+
+.feedback-sidebar-panel {
+  width: min(320px, calc(100vw - 2rem));
+  background-color: #fffde7;
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  transform: translateX(0);
+  transition: transform var(--transition-speed), opacity var(--transition-speed);
+}
+
+.feedback-sidebar.collapsed .feedback-sidebar-panel {
+  transform: translateX(120%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.feedback-sidebar.collapsed .feedback-sidebar-toggle {
+  background-color: #eeeeee;
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.feedback-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem 0.5rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.feedback-sidebar-header h2 {
+  font-size: 1.05rem;
+  color: var(--accent);
+}
+
+.feedback-sidebar-close {
+  background: none;
+  border: none;
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.feedback-sidebar-close:hover,
+.feedback-sidebar-close:focus {
+  color: var(--text-primary);
+  outline: none;
+}
+
+.feedback-sidebar-content {
+  padding: 0.75rem 1rem 1rem;
+  font-size: 0.95rem;
+  color: #6d4c41;
+  min-height: 2.5rem;
+}
+
+@media (max-width: 900px) {
+  .feedback-sidebar {
+    position: static;
+    align-items: stretch;
+    margin-bottom: 1rem;
+  }
+
+  .feedback-sidebar-panel {
+    width: 100%;
+    transform: none;
+    opacity: 1;
+    pointer-events: auto;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  .feedback-sidebar.collapsed .feedback-sidebar-panel {
+    display: none;
+    transform: none;
+    opacity: 1;
+  }
+}
+
 footer {
   margin-top: 2rem;
   text-align: center;


### PR DESCRIPTION
## Summary
- add a floating feedback sidebar so hints are visible near the panel controls
- style the sidebar with responsive behaviour and accessibility-friendly toggle controls
- synchronise sidebar content with the existing feedback messages for consistent guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbb49953408322b4c43b87ce94f843