### PR TITLE
Add collapsible feedback sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,16 +16,37 @@
   </header>
 
   <main>
-    <!-- Button to start or reset the simulation -->
-    <div class="controls">
-      <button id="startButton" class="primary">Start Simulation</button>
-      <button id="newScenarioButton" class="secondary">New Scenario</button>
-    </div>
+    <div class="game-layout">
+      <div class="game-content">
+        <!-- Button to start or reset the simulation -->
+        <div class="controls">
+          <button id="startButton" class="primary">Start Simulation</button>
+          <button id="newScenarioButton" class="secondary">New Scenario</button>
+        </div>
 
-    <!-- Container where the panels will be rendered -->
-    <div id="panel-container" class="panel-container"></div>
-    <!-- Feedback area for messages -->
-    <div id="feedback" class="feedback"></div>
+        <!-- Container where the panels will be rendered -->
+        <div id="panel-container" class="panel-container"></div>
+      </div>
+
+      <!-- Collapsible feedback sidebar -->
+      <aside
+        id="feedbackSidebar"
+        class="feedback-sidebar collapsed"
+        aria-expanded="false"
+      >
+        <button
+          id="feedbackToggle"
+          class="feedback-toggle"
+          type="button"
+          aria-controls="feedback"
+          aria-expanded="false"
+        >
+          <span class="toggle-label">Feedback</span>
+          <span class="chevron" aria-hidden="true"></span>
+        </button>
+        <div id="feedback" class="feedback" role="status" aria-live="polite"></div>
+      </aside>
+    </div>
 
     <!-- Training video section placed at the bottom -->
     <div class="video-section">

--- a/script.js
+++ b/script.js
@@ -28,6 +28,36 @@ const panelContainer = document.getElementById('panel-container');
 const startButton = document.getElementById('startButton');
 const newScenarioButton = document.getElementById('newScenarioButton');
 const feedbackEl = document.getElementById('feedback');
+const feedbackSidebar = document.getElementById('feedbackSidebar');
+const feedbackToggleButton = document.getElementById('feedbackToggle');
+
+if (feedbackToggleButton && feedbackSidebar) {
+  setFeedbackSidebarExpanded(false);
+  feedbackToggleButton.addEventListener('click', () => {
+    toggleFeedbackSidebar();
+  });
+}
+
+/**
+ * Expand or collapse the feedback sidebar.
+ *
+ * @param {boolean} expanded - Whether the sidebar should be expanded.
+ */
+function setFeedbackSidebarExpanded(expanded) {
+  if (!feedbackSidebar || !feedbackToggleButton) return;
+  feedbackSidebar.classList.toggle('collapsed', !expanded);
+  feedbackSidebar.setAttribute('aria-expanded', String(expanded));
+  feedbackToggleButton.setAttribute('aria-expanded', String(expanded));
+}
+
+/**
+ * Toggle the current state of the feedback sidebar.
+ */
+function toggleFeedbackSidebar() {
+  if (!feedbackSidebar) return;
+  const isCollapsed = feedbackSidebar.classList.contains('collapsed');
+  setFeedbackSidebarExpanded(isCollapsed);
+}
 
 /**
  * Initialize a new game scenario.
@@ -328,9 +358,11 @@ function updateFeedback(message) {
   if (!message) {
     feedbackEl.style.display = 'none';
     feedbackEl.textContent = '';
+    setFeedbackSidebarExpanded(false);
   } else {
     feedbackEl.style.display = 'block';
     feedbackEl.textContent = message;
+    setFeedbackSidebarExpanded(true);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -52,6 +52,89 @@ main {
   margin: 0 auto;
 }
 
+.game-layout {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.game-content {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.feedback-sidebar {
+  flex: 0 0 320px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  position: sticky;
+  top: 1rem;
+  transition: max-height var(--transition-speed), box-shadow var(--transition-speed);
+  max-height: 3.5rem;
+  overflow: hidden;
+}
+
+.feedback-sidebar[aria-expanded="true"] {
+  max-height: 600px;
+}
+
+.feedback-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: transparent;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  color: var(--accent);
+}
+
+.feedback-toggle:hover,
+.feedback-toggle:focus-visible {
+  background-color: rgba(25, 118, 210, 0.08);
+  outline: none;
+}
+
+.feedback-toggle .chevron {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform var(--transition-speed);
+}
+
+.feedback-sidebar[aria-expanded="true"] .feedback-toggle .chevron {
+  transform: rotate(-135deg);
+}
+
+.feedback-sidebar.collapsed .feedback {
+  display: none;
+}
+
+@media (max-width: 960px) {
+  .game-layout {
+    flex-direction: column;
+  }
+
+  .feedback-sidebar {
+    position: static;
+    width: 100%;
+    max-height: none;
+  }
+
+  .feedback-sidebar.collapsed {
+    max-height: 3.5rem;
+  }
+}
+
 /* Buttons styling */
 .controls {
   display: flex;


### PR DESCRIPTION
## Summary
- restructure the game layout to place the feedback area in a collapsible sidebar with accessible markup
- add styling and toggle affordances for the sidebar while keeping the feedback container for existing tests
- update the game script to control the sidebar state and open it automatically when new feedback arrives

## Testing
- pytest tests/test_site_structure.py

------
https://chatgpt.com/codex/tasks/task_e_68dbbaa8fd508322a7ba1d18bbbd92fd